### PR TITLE
do not lowercase basename

### DIFF
--- a/main.pl
+++ b/main.pl
@@ -699,9 +699,9 @@ sub parse_sfd ( $ ) {
     }
 
     $$result{'basename'} =~ s/-/_/g;
-    $$result{'basename'} = lc $$result{'basename'};
     $$result{'BASENAME'} = uc $$result{'basename'};
-    $$result{'Basename'} = ucfirst $$result{'basename'};
+    $$result{'Basename'} = lc $$result{'basename'};
+    $$result{'Basename'} = ucfirst $$result{'Basename'};
     ($result->{BaseName} = $result->{base}) =~ s/Base//;
 
     return $result;

--- a/sfdc
+++ b/sfdc
@@ -699,9 +699,9 @@ sub parse_sfd ( $ ) {
     }
 
     $$result{'basename'} =~ s/-/_/g;
-    $$result{'basename'} = lc $$result{'basename'};
     $$result{'BASENAME'} = uc $$result{'basename'};
-    $$result{'Basename'} = ucfirst $$result{'basename'};
+    $$result{'Basename'} = lc $$result{'basename'};
+    $$result{'Basename'} = ucfirst $$result{'Basename'};
     ($result->{BaseName} = $result->{base}) =~ s/Base//;
 
     return $result;


### PR DESCRIPTION
This reapplies the fix for https://github.com/adtools/sfdc/issues/3
which commit 2026f110a22 (https://github.com/adtools/sfdc/issues/8)
seems to have reverted without any specific explanation.