### PR TITLE
Fixed perl error related to varargs in StubAOS4.pl

### DIFF
--- a/StubAOS4.pl
+++ b/StubAOS4.pl
@@ -294,7 +294,7 @@ BEGIN {
 
       my @newargs;
 
-      for my $i (0 .. $#{@{$prototype->{___args}}}) {
+      for my $i (0 .. $#{$prototype->{___args}}) {
           if ($prototype->{subtype} ne 'methodcall' ||
             $i != $prototype->{numargs} - 2 ) {
             push @newargs, $prototype->{___args}[$i];

--- a/StubMOS.pl
+++ b/StubMOS.pl
@@ -276,7 +276,7 @@ BEGIN {
 
       my @newargs;
 
-      for my $i (0 .. $#{@{$prototype->{___args}}}) {
+      for my $i (0 .. $#{$prototype->{___args}}) {
           if ($prototype->{subtype} ne 'methodcall' ||
             $i != $prototype->{numargs} - 2 ) {
             push @newargs, $prototype->{___args}[$i];


### PR DESCRIPTION
Fixed this code, which was giving the error 'Can't use string ("n") as an ARRAY ref while "strict refs" in use'