### PR TITLE
Properly handle function pointer arguments and returns

### DIFF
--- a/Stub.pl
+++ b/Stub.pl
@@ -145,8 +145,15 @@ BEGIN {
             printf "struct $struct;\n";
       }
 
-      
-      print "__inline $$prototype{'return'}\n";
+
+      my $rettype_prefix = $prototype->{return};
+      my $rettype_postfix = "";
+      if ($prototype->{return} =~ /(.*\(\*+)(\).*)/) {
+        $rettype_prefix = $1;
+        $rettype_postfix = $2;
+      }
+
+      print "__inline $rettype_prefix\n";
       print "$$prototype{'funcname'}(";
       if (!$prototype->{nb}) {
           if ($$prototype{'numargs'} == 0) {
@@ -157,7 +164,7 @@ BEGIN {
           }
       }
       print join (', ', @{$$prototype{'___args'}});
-      print ")";
+      print ")$rettype_postfix";
       
     }
 

--- a/Stub68k.pl
+++ b/Stub68k.pl
@@ -28,7 +28,13 @@ BEGIN {
             print "  BASE_EXT_DECL\n";
           }
           if (!$prototype->{nr}) {
-            print "  register $prototype->{return} _res __asm(\"d0\");\n";
+            my $rettype_prefix = $prototype->{return};
+            my $rettype_postfix = "";
+            if ($prototype->{return} =~ /(.*\(\*+)(\).*)/) {
+              $rettype_prefix = $1;
+              $rettype_postfix = $2;
+            }
+            print "  register $rettype_prefix _res $rettype_postfix __asm(\"d0\");\n";
           }
           if (!$prototype->{nb}) {
             print "  register $sfd->{basetype} _base __asm(\"a6\") " .

--- a/main.pl
+++ b/main.pl
@@ -908,16 +908,17 @@ sub parse_proto ( $$$ ) {
       my $___name = '';
       my $___arg  = '';
 
-      # MorhOS includes use __CLIB_PROTOTYPE for some reason ...
+      # MorphOS includes use __CLIB_PROTOTYPE for some reason ...
       if ($arg =~ /.*\(.*?\)\s*(__CLIB_PROTOTYPE)?\(.*\)/) {
           my $type1;
           my $type2;
-          
-          ($type1, $name, $type2) =
-            ( $arg =~ /^\s*(.*)\(\s*\*+\s*(\w+)\s*\)\s*(\w*\(.*\))\s*/ );
-          $type = "$type1(*)$type2";
+          my $ptr;
+
+          ($type1, $ptr, $name, $type2) =
+            ( $arg =~ /^\s*(.*)\(\s*(\*+)\s*(\w+)\s*\)\s*(\w*\(.*\))\s*/ );
+          $type = "$type1($ptr)$type2";
           $___name = "___$name";
-          $___arg = "$type1(*___$name) $type2";
+          $___arg = "$type1($ptr"."___$name) $type2";          
       }
       elsif ($arg !~ /^\.\.\.$/) {
           ($type, $name) = ( $arg =~ /^\s*(.*?[\s*]*?)\s*(\w+)\s*$/ );

--- a/main.pl
+++ b/main.pl
@@ -918,7 +918,7 @@ sub parse_proto ( $$$ ) {
             ( $arg =~ /^\s*(.*)\(\s*(\*+)\s*(\w+)\s*\)\s*(\w*\(.*\))\s*/ );
           $type = "$type1($ptr)$type2";
           $___name = "___$name";
-          $___arg = "$type1($ptr"."___$name) $type2";          
+          $___arg = "$type1($ptr"."___$name) $type2";
       }
       elsif ($arg !~ /^\.\.\.$/) {
           ($type, $name) = ( $arg =~ /^\s*(.*?[\s*]*?)\s*(\w+)\s*$/ );


### PR DESCRIPTION
While attempted to create linklib stubs for AmiSSL/OpenSSL, I found some instances where function pointer arguments were not handled correctly if the function in the argument returned a pointer. Also, functions that returned a function pointer were not formatted correctly, creating bad code - now fixed.