### PR TITLE
Changed the 68k vbcc macro library base type to void *

### DIFF
--- a/MacroVBCC68k.pl
+++ b/MacroVBCC68k.pl
@@ -22,7 +22,7 @@ BEGIN {
       
       my $regswap = "";
       
-      my $function_start = $$prototype{'return'} ." __" . $$prototype{'funcname'} . "(__reg(\"a6\") struct Library * ";
+      my $function_start = $$prototype{'return'} ." __" . $$prototype{'funcname'} . "(__reg(\"a6\") void * ";
       my $function = $function_start;
       
       if ($$prototype{private})

--- a/Proto.pl
+++ b/Proto.pl
@@ -38,6 +38,8 @@ BEGIN {
       print "#  else\n";
       print "#   include <inline/${basename}.h>\n";
       print "#  endif\n";
+      print "# #elif defined(__VBCC__)\n";
+      print "#   include <inline/${basename}_protos.h>\n";
       print "# else\n";
       print "#  include <pragmas/${basename}_pragmas.h>\n";
       print "# endif\n";

--- a/Proto.pl
+++ b/Proto.pl
@@ -38,7 +38,7 @@ BEGIN {
       print "#  else\n";
       print "#   include <inline/${basename}.h>\n";
       print "#  endif\n";
-      print "# #elif defined(__VBCC__)\n";
+      print "# elif defined(__VBCC__)\n";
       print "#   include <inline/${basename}_protos.h>\n";
       print "# else\n";
       print "#  include <pragmas/${basename}_pragmas.h>\n";


### PR DESCRIPTION
The 68k vbcc inline macros now have `void *` instead of `struct Library *` for their library base. The rationale behind this change is to get rid of the `warning 85 (...): assignment of different pointers` warnings in cases where the library base is declared as a specialized type, e.g. `struct ExecBase *SysBase`. This is in line with the official [vbcc_target_m68k-amigaos.lha](http://phoenix.owl.de/vbcc/2022-05-22/vbcc_target_m68k-amigaos.lha).