### PR TITLE
Use AROS_LCxNR() for functions that don't return a value.

### DIFF
--- a/MacroAROS.pl
+++ b/MacroAROS.pl
@@ -41,7 +41,8 @@ BEGIN {
 
       if ($$prototype{'type'} eq 'function') {
           printf "      AROS_LC%d%s(%s, %s, \\\n",
-          $$prototype{'numargs'}, $prototype->{nb} ? "I" : "",
+          $$prototype{'numargs'},
+          $$prototype{'return'} eq 'void' || $$prototype{'return'} eq 'VOID' ? "NR" : "",
           $$prototype{'return'}, $$prototype{'funcname'};
       }
       else {

--- a/sfdc
+++ b/sfdc
@@ -3386,7 +3386,8 @@ BEGIN {
 
       if ($$prototype{'type'} eq 'function') {
           printf "      AROS_LC%d%s(%s, %s, \\\n",
-          $$prototype{'numargs'}, $prototype->{nb} ? "I" : "",
+          $$prototype{'numargs'},
+          $$prototype{'return'} eq 'void' || $$prototype{'return'} eq 'VOID' ? "NR" : "",
           $$prototype{'return'}, $$prototype{'funcname'};
       }
       else {


### PR DESCRIPTION
Fixes "variable or field '__ret' declared as void" errors when compiling for x86_64-aros (ABIv11) using the generated headers.